### PR TITLE
chore(package): move coc.nvim to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,10 +144,10 @@
     "npm-run-all": "~4.1.5",
     "prettier": "~2.0.4",
     "rimraf": "~3.0.2",
+    "coc.nvim": "~0.0.74",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "coc.nvim": "~0.0.74",
     "stylelint-lsp": "~1.0.6"
   }
 }


### PR DESCRIPTION
Avoid install unnecessary coc.nvim when using `:CocInstall`