### PR TITLE
 Add sass to default filetype list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ const DEFAULT_FILETYPES = [
   "css",
   "less",
   "postcss",
+  "sass",
   "scss",
   "sugarss",
   "vue",


### PR DESCRIPTION
Discovered that if the filetype is set to sass, then the stylelintplus plugin does not load.  Seems to be a common practice to set files ending in a .scss extension as a 'sass' filetype.  Discovered in #25  